### PR TITLE
Removed hardcoded paths and added support for multiple ABIs

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -15,9 +15,13 @@ cmake_minimum_required(VERSION 3.4.1)
 set(CMAKE_SHARED_LINKER_FLAGS
     "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
 
-include_directories( "C:\\SFML-2.4.2_SRC\\include" )
-link_directories( "C:\\SFML_ANDROID_2.4.2\\lib\\armeabi-v7a" )
+include_directories(${SFML_INCLUDE_DIR})
+link_directories(${SFML_LIBRARY_DIR})
+link_directories(${SFML_EXT_LIBRARY_DIR})
 
+message(DEBUG "SFML include dir: ${SFML_INCLUDE_DIR}")
+message(DEBUG "SFML lib dir: ${SFML_LIBRARY_DIR}")
+message(DEBUG "SFML extlib dir: ${SFML_EXT_LIBRARY_DIR}")
 
 add_library( # Sets the name of the library.
              native-lib

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -16,12 +16,13 @@ set(CMAKE_SHARED_LINKER_FLAGS
     "${CMAKE_SHARED_LINKER_FLAGS} -u ANativeActivity_onCreate")
 
 include_directories(${SFML_INCLUDE_DIR})
-link_directories(${SFML_LIBRARY_DIR})
-link_directories(${SFML_EXT_LIBRARY_DIR})
+link_directories("${SFML_LIBRARY_DIR}${ANDROID_ABI}/")
+link_directories("${SFML_EXT_LIBRARY_DIR}${ANDROID_ABI}/")
 
-message(DEBUG "SFML include dir: ${SFML_INCLUDE_DIR}")
-message(DEBUG "SFML lib dir: ${SFML_LIBRARY_DIR}")
-message(DEBUG "SFML extlib dir: ${SFML_EXT_LIBRARY_DIR}")
+message(STATUS "SFML include dir: ${SFML_INCLUDE_DIR}")
+message(STATUS "SFML lib dir: ${SFML_LIBRARY_DIR}${ANDROID_ABI}/")
+message(STATUS "SFML extlib dir: ${SFML_EXT_LIBRARY_DIR}${ANDROID_ABI}/")
+message(STATUS "ABI ${ANDROID_ABI}")
 
 add_library( # Sets the name of the library.
              native-lib

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -24,9 +24,12 @@ android {
                 arguments "-DANDROID_TOOLCHAIN=clang",
                         "-DANDROID_STL=c++_shared",
                         "-DSFML_INCLUDE_DIR=${ndkDir}/sources/sfml/include",
-                        "-DSFML_LIBRARY_DIR=${ndkDir}/sources/sfml/lib/armeabi-v7a/",
-                        "-DSFML_EXT_LIBRARY_DIR=${ndkDir}/sources/sfml/extlibs/lib/armeabi-v7a/"
+                        "-DSFML_LIBRARY_DIR=${ndkDir}/sources/sfml/lib/",
+                        "-DSFML_EXT_LIBRARY_DIR=${ndkDir}/sources/sfml/extlibs/lib/"
                 abiFilters 'armeabi-v7a'
+                // multiple ABIs are supported
+                // but you have to compile SFML for every ABI you want to support
+                // abiFilters 'armeabi-v7a',  'armeabi'
             }
         }
     }
@@ -50,7 +53,7 @@ android {
     sourceSets {
         main {
             // let gradle pack the shared library into apk
-            jniLibs.srcDirs = ['/opt/android-sdk/ndk-bundle/sources/sfml/lib', '/opt/android-sdk/ndk-bundle/sources/sfml/extlibs/lib/']
+            jniLibs.srcDirs = ["${ndkDir}/sources/sfml/lib", "${ndkDir}/sources/sfml/extlibs/lib/"]
         }
     }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,5 +1,13 @@
 apply plugin: 'com.android.application'
 
+def ndkDir = System.getenv("ANDROID_NDK")
+def propertiesFile = project.rootProject.file('local.properties')
+if (propertiesFile.exists()) {
+    Properties properties = new Properties()
+    properties.load(propertiesFile.newDataInputStream())
+    ndkDir = properties.getProperty('ndk.dir')
+}
+
 android {
     compileSdkVersion 25
     buildToolsVersion "25.0.3"
@@ -13,7 +21,11 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++14 -frtti -fexceptions"
-                arguments "-DANDROID_TOOLCHAIN=clang", "-DANDROID_STL=stlport_shared"
+                arguments "-DANDROID_TOOLCHAIN=clang",
+                        "-DANDROID_STL=c++_shared",
+                        "-DSFML_INCLUDE_DIR=${ndkDir}/sources/sfml/include",
+                        "-DSFML_LIBRARY_DIR=${ndkDir}/sources/sfml/lib/armeabi-v7a/",
+                        "-DSFML_EXT_LIBRARY_DIR=${ndkDir}/sources/sfml/extlibs/lib/armeabi-v7a/"
                 abiFilters 'armeabi-v7a'
             }
         }
@@ -38,7 +50,7 @@ android {
     sourceSets {
         main {
             // let gradle pack the shared library into apk
-            jniLibs.srcDirs = ['C:\\SFML_ANDROID_2.4.2\\lib'/*, 'C:\\SFML-2.4.2_SRC\\extlibs\\libs-android'*/]
+            jniLibs.srcDirs = ['/opt/android-sdk/ndk-bundle/sources/sfml/lib', '/opt/android-sdk/ndk-bundle/sources/sfml/extlibs/lib/']
         }
     }
 


### PR DESCRIPTION
There were some hardcoded paths in the templates which are not necessary. 
When you build SFML and execute "make install" SFML will get installed inside your NDK installation (With ABI prefix). So i changed the Gradle and Cmake files to search SFML there by default. 

Also i added support for multiple ABIs, by using ANDROID_ABI in the cmake script